### PR TITLE
Make participant clickable in order edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ dist
 !extensions/product_review
 /themes
 .idea/*
-evercamps
+/evercamps
 .vscode
 npm-debug.log
 /package-log.json

--- a/packages/evercamps/src/components/admin/oms/orderEdit/items/Name.jsx
+++ b/packages/evercamps/src/components/admin/oms/orderEdit/items/Name.jsx
@@ -21,7 +21,21 @@ export function Name({ name, productSku, productUrl, variantOptions = [], regist
             {registrations.map((reg, idx) => (
               <div key={idx} className="mb-2">
                 <div className="font-semibold">Participant {idx + 1}:</div>
-                <div>Name: {reg.firstName} {reg.lastName}</div>
+                <div>
+                  <span className="font-semibold">Name: </span>
+                  {reg.participant?.editUrl ? (
+                    <a
+                      href={reg.participant.editUrl}
+                      className="hover:underline"
+                    >
+                      {reg.firstName} {reg.lastName}
+                    </a>
+                  ) : (
+                    <span>
+                      {reg.firstName} {reg.lastName}
+                    </span>
+                  )}
+                </div>              
               </div>
             ))}
           </div>

--- a/packages/evercamps/src/modules/camp/graphql/types/Registration/Registration.resolvers.js
+++ b/packages/evercamps/src/modules/camp/graphql/types/Registration/Registration.resolvers.js
@@ -28,7 +28,7 @@ export default {
         return row ? camelCase(row) : null;
       },
       participant: async (registration, _, { pool }) => {
-      const row = await await getRegistrationsBaseQuery(pool)
+      const row = await getRegistrationsBaseQuery(pool)
         .where("registration_id", "=", registration.registrationId)
         .load(pool);
       return row ? camelCase(row) : null;

--- a/packages/evercamps/src/modules/checkout/services/orderCreator.ts
+++ b/packages/evercamps/src/modules/checkout/services/orderCreator.ts
@@ -121,7 +121,7 @@ async function saveOrderItems(
         .load(connection);
 
         let participantId;
-
+        let registrationId;
       if (participant) {
         participantId = participant.participant_id;
       } else {
@@ -134,17 +134,19 @@ async function saveOrderItems(
 
         participantId = participant.insertId;
       }
-      await insert('registration')
+      let registration = await insert('registration')
         .given({
           registration_participant_id: participantId,
           registration_product_id: item.getData('product_id'),
         })
         .execute(connection);
+        registrationId = registration.insertId;
         await insert('order_item_registration')
           .given({
             order_item_id: orderItem.insertId,
             first_name: reg.firstName,
-            last_name: reg.lastName
+            last_name: reg.lastName,
+            registration_id: registrationId
           })
           .execute(connection);        
       }

--- a/packages/evercamps/src/modules/oms/graphql/types/Order/Order.graphql
+++ b/packages/evercamps/src/modules/oms/graphql/types/Order/Order.graphql
@@ -54,8 +54,10 @@ Represents a registration attached to a specific order item.
 type OrderItemRegistration {
   orderItemRegistrationId: ID!
   orderItemId: ID!
+  registrationId: ID!
   firstName: String!
   lastName: String!
+  participant: Participant
 }
 
 """

--- a/packages/evercamps/src/modules/oms/graphql/types/Order/Order.resolvers.js
+++ b/packages/evercamps/src/modules/oms/graphql/types/Order/Order.resolvers.js
@@ -128,5 +128,16 @@ export default {
     subTotal: ({ lineTotal }) =>
       // This field is deprecated, use lineTotal instead
       lineTotal
+  },
+  OrderItemRegistration: {
+    participant: async ({ registrationId }, _, { pool }) => {
+      const query = select('participant.uuid')
+      .from('participant');
+      query.leftJoin('registration')
+      .on('registration.registration_participant_id', '=', 'participant.participant_id');
+      const participant = await query.where('registration.registration_id', '=', registrationId)
+      .load(pool);
+      return participant ? camelCase(participant) : null;
+    }
   }
 };

--- a/packages/evercamps/src/modules/oms/migration/Version-1.0.2.js
+++ b/packages/evercamps/src/modules/oms/migration/Version-1.0.2.js
@@ -1,7 +1,6 @@
 import { execute } from '@evershop/postgres-query-builder';
 
 export default async (connection) => {
-  // Rename sub_total column to line_total
   await execute(
     connection,
     `CREATE TABLE order_item_registration (

--- a/packages/evercamps/src/modules/oms/migration/Version-1.0.3.js
+++ b/packages/evercamps/src/modules/oms/migration/Version-1.0.3.js
@@ -1,0 +1,16 @@
+import { execute } from '@evershop/postgres-query-builder';
+
+export default async (connection) => {
+  await execute(
+    connection,
+    `
+    ALTER TABLE order_item_registration 
+    ADD COLUMN IF NOT EXISTS registration_id INT;
+
+    ALTER TABLE order_item_registration
+    ADD CONSTRAINT FK_REGISTRATION
+    FOREIGN KEY (registration_id) REFERENCES registration (registration_id)
+    ON DELETE CASCADE;
+    `
+  );  
+};

--- a/packages/evercamps/src/modules/oms/pages/admin/orderEdit/Items.jsx
+++ b/packages/evercamps/src/modules/oms/pages/admin/orderEdit/Items.jsx
@@ -152,6 +152,9 @@ export const query = `
         registrations {
           firstName
           lastName
+          participant {
+              editUrl
+            }
         }
         productName
         productSku


### PR DESCRIPTION
Clicking the participant in order edit now brings you to the participants edit page
Participants will only be clickable with new orders, will not work on old ones.
Added registrationId FK to order item registration
Made small change in gitignore
Closes #54 